### PR TITLE
Fix typo in local API docs

### DIFF
--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -13,7 +13,7 @@ It is worth familiarising yourself with [Decent Messaging terminology](terminolo
  
 The base URL for the API is `http://localhost:7771/api/v1/`.
 
-Response will be a JSON object, with a `status` (`ok` or `error`) and a free form text `descripption`.
+Response will be a JSON object, with a `status` (`ok` or `error`) and a free form text `description`.
 
 ### Personal messages
 


### PR DESCRIPTION
## Summary
- fix small typo in `docs/local-api.md`

## Testing
- `git status --short`