### PR TITLE
Fix missing break in LocalWebServer

### DIFF
--- a/src/main/network/LocalWebServer.java
+++ b/src/main/network/LocalWebServer.java
@@ -171,9 +171,10 @@ public class LocalWebServer extends NanoHTTPD
 				} else {
 					responseObj.put("status", "error");
 					responseObj.put("description", "Invalid method. Must use GET or POST method.");
-				}
-				
-			case "/api/v1/messages":
+                                }
+                                break;
+
+                        case "/api/v1/messages":
 				
 				if (session.getMethod() == Method.POST) {
 					


### PR DESCRIPTION
## Summary
- prevent fall-through from `/api/v1/personal-messages` to `/api/v1/messages`

## Testing
- `javac -cp "lib/*:src" -d /tmp/compile_classes $(find src -name "*.java")`